### PR TITLE
Fix deprecated forked link

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ when the argument given is already a string.
 with a harcoded, static or final local regex as a static final to avoid recompiling the regex.
 
 ## 0.1.1
-- forked from [WorksApplication's original plugin](WorksApplications/findbugs-plugin).
+- forked from [WorksApplication's original plugin](https://github.com/arxes-tolina/findbugs-plugin).
 Awesome plugin, but Findbugs 2 only.
 - upgraded to Findbugs 3
 - rewrote most error messages to be more specific


### PR DESCRIPTION
Tal vez en una época ese link anduvo, pero ahora ya no funciona más, así que directamente puse la url exacta (me parece que es esa).
